### PR TITLE
Improve error reporting by adding information about the context and the location

### DIFF
--- a/src/Glutinum.Converter/Reader/EnumDeclaration.fs
+++ b/src/Glutinum.Converter/Reader/EnumDeclaration.fs
@@ -37,9 +37,20 @@ let private readEnumMembers
                 | GlueLiteral.Int _
                 | GlueLiteral.Float _ as value -> value
                 | GlueLiteral.Bool _ ->
-                    failwith "Boolean literals are not supported in enums"
+                    failwith (
+                        generateReaderError
+                            "enum member"
+                            "Boolean literals are not supported in enums"
+                            initializer
+                    )
 
-            | None -> failwith "readEnumCases: Unsupported enum initializer"
+            | None ->
+                failwith (
+                    generateReaderError
+                        "enum member"
+                        "readEnumCases: Unsupported enum initializer"
+                        initializer
+                )
 
     let name = unbox<Ts.Identifier> enumMember.name
 

--- a/src/Glutinum.Converter/Reader/FunctionDeclaration.fs
+++ b/src/Glutinum.Converter/Reader/FunctionDeclaration.fs
@@ -23,7 +23,13 @@ let readFunctionDeclaration
     let name =
         match declaration.name with
         | Some name -> name.getText ()
-        | None -> failwith "readFunctionDeclaration: Missing name"
+        | None ->
+            failwith (
+                Utils.generateReaderError
+                    "function declaration"
+                    "Missing name"
+                    declaration
+            )
 
     {
         IsDeclared = isDeclared

--- a/src/Glutinum.Converter/Reader/NamedDeclaration.fs
+++ b/src/Glutinum.Converter/Reader/NamedDeclaration.fs
@@ -78,4 +78,9 @@ let readNamedDeclaration
         |> GlueMember.IndexSignature
 
     | _ ->
-        failwith $"tryReadNamedDeclaration: Unsupported kind {declaration.kind}"
+        failwith (
+            Utils.generateReaderError
+                "named declaration"
+                $"Unsupported kind %A{declaration.kind}"
+                declaration
+        )

--- a/src/Glutinum.Converter/Reader/Node.fs
+++ b/src/Glutinum.Converter/Reader/Node.fs
@@ -28,5 +28,11 @@ let readNode (reader: TypeScriptReader) (node: Ts.Node) : GlueType =
         reader.ReadClassDeclaration(node :?> Ts.ClassDeclaration)
 
     | unsupported ->
-        printfn $"readNode: Unsupported kind {unsupported}"
+        printfn
+            "%s"
+            (Utils.generateReaderError
+                "node"
+                $"Unsupported node kind %A{unsupported}"
+                node)
+
         GlueType.Discard

--- a/src/Glutinum.Converter/Reader/TypeNode.fs
+++ b/src/Glutinum.Converter/Reader/TypeNode.fs
@@ -29,7 +29,13 @@ let readTypeNode (reader: TypeScriptReader) (typeNode: Ts.TypeNode) : GlueType =
 
         let fullName =
             match symbolOpt with
-            | None -> failwith "readTypeNode: Missing symbol"
+            | None ->
+                failwith (
+                    generateReaderError
+                        "type node"
+                        "Missing symbol"
+                        typeReferenceNode
+                )
             | Some symbol -> checker.getFullyQualifiedName symbol
 
         // Could this detect false positive, if the library defined
@@ -172,4 +178,10 @@ let readTypeNode (reader: TypeScriptReader) (typeNode: Ts.TypeNode) : GlueType =
             |> GlueType.ClassDeclaration
         | _ -> GlueType.Primitive GluePrimitive.Any
 
-    | _ -> failwith $"readTypeNode: Unsupported kind {typeNode.kind}"
+    | _ ->
+        failwith (
+            generateReaderError
+                "type node"
+                $"Unsupported kind %A{typeNode.kind}"
+                typeNode
+        )

--- a/src/Glutinum.Converter/Reader/TypeOperatorNode.fs
+++ b/src/Glutinum.Converter/Reader/TypeOperatorNode.fs
@@ -20,7 +20,13 @@ let readTypeOperatorNode
                 reader.checker.getSymbolAtLocation !!typeReferenceNode.typeName
 
             match symbolOpt with
-            | None -> failwith "readTypeOperator: Missing symbol"
+            | None ->
+                failwith (
+                    Utils.generateReaderError
+                        "type operator (keyof)"
+                        "Missing symbol"
+                        node
+                )
 
             | Some symbol ->
                 match symbol.declarations with
@@ -31,9 +37,26 @@ let readTypeOperatorNode
                     reader.ReadInterfaceDeclaration interfaceDeclaration
                     |> GlueType.KeyOf
 
-                | None -> failwith "readTypeOperator: Missing declaration"
+                | None ->
+                    failwith (
+                        Utils.generateReaderError
+                            "type operator (keyof)"
+                            "Missing declarations"
+                            node
+                    )
 
         else
-            failwith "readTypeOperator: Unsupported type reference"
+            failwith (
+                Utils.generateReaderError
+                    "type operator (keyof)"
+                    $"Was expecting a type reference instead got a Node of type %A{node.``type``.kind}"
+                    node
+            )
 
-    | _ -> failwith $"readTypeOperator: Unsupported operator {node.operator}"
+    | _ ->
+        failwith (
+            Utils.generateReaderError
+                "type operator"
+                $"Unsupported operator %A{node.operator}"
+                node
+        )

--- a/src/Glutinum.Converter/Reader/UnionTypeNode.fs
+++ b/src/Glutinum.Converter/Reader/UnionTypeNode.fs
@@ -67,8 +67,12 @@ let rec private readUnionTypeCases
             let symbol =
                 Option.defaultWith
                     (fun () ->
-                        failwith
-                            "readUnionTypeCases: Unsupported type reference, missing symbol"
+                        failwith (
+                            generateReaderError
+                                "union type cases"
+                                "Missing symbol"
+                                typeReferenceNode
+                        )
                     )
                     symbolOpt
 
@@ -103,7 +107,13 @@ let rec private readUnionTypeCases
                     |> List.singleton
                     |> Some
                 | _ ->
-                    failwith "readUnionTypeCases: Unsupported type reference"
+                    failwith (
+                        generateReaderError
+                            "union type cases"
+                            "Unsupported type reference reach a point where it was expected to have flags like Any"
+                            typeReferenceNode
+                    )
+
 
         // else
         //     symbol.declarations

--- a/src/Glutinum.Converter/Reader/Utils.fs
+++ b/src/Glutinum.Converter/Reader/Utils.fs
@@ -46,3 +46,26 @@ let tryReadLiteral (expression: Ts.Node) =
         let text = expression.getText ()
 
         tryReadNumericLiteral text
+
+let generateReaderError
+    (errorContext: string)
+    (reason: string)
+    (node: Ts.Node)
+    =
+    let sourceFile = node.getSourceFile ()
+    let lineAndChar = sourceFile.getLineAndCharacterOfPosition node.pos
+    let line = int lineAndChar.line + 1
+    let column = int lineAndChar.character + 1
+
+    $"""Error while reading %s{errorContext} in
+%s{sourceFile.fileName}(%d{line},%d{column})
+
+%s{reason}
+
+--- Text ---
+%s{node.getFullText ()}
+---
+
+--- Parent text ---
+%s{node.parent.getFullText ()}
+---"""

--- a/src/Glutinum.Converter/Reader/VariableStatement.fs
+++ b/src/Glutinum.Converter/Reader/VariableStatement.fs
@@ -30,7 +30,13 @@ let readVariableStatement
             | Ts.SyntaxKind.Identifier ->
                 let id: Ts.Identifier = !!declaration.name
                 id.getText ()
-            | _ -> failwith "readVariableStatement: Unsupported kind"
+            | _ ->
+                failwith (
+                    Utils.generateReaderError
+                        "variable statement"
+                        "Unable to read variable name"
+                        declaration
+                )
 
         ({
             Name = name


### PR DESCRIPTION
Related to the discussion in #24 

Depending on where the error occurs, the parent information can overwhelming (the whole file can be reported) but I expect that over time as we support more and more top level syntax this case is going to be less and less frequent.

For now, as a workaround to too small console history, people can log the output to a file.