### PR TITLE
feat: Add support for Mapped Types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Feliz" Version="2.7.0" />
     <PackageVersion Include="Feliz.Bulma" Version="3.0.0" />
     <PackageVersion Include="FSharp.Core" Version="8.0.101" />
+    <PackageVersion Include="FsToolkit.ErrorHandling" Version="4.16.0" />
     <PackageVersion Include="Glutinum.Chalk" Version="1.0.0" />
     <PackageVersion Include="Glutinum.Feliz.Iconify" Version="2.0.0" />
     <PackageVersion Include="Glutinum.IconifyIcons.Lucide" Version="1.0.0" />

--- a/src/Glutinum.Converter.CLI/packages.lock.json
+++ b/src/Glutinum.Converter.CLI/packages.lock.json
@@ -31,6 +31,7 @@
       "glutinum.converter": {
         "type": "Project",
         "dependencies": {
+          "FSToolkit.ErrorHandling": "[4.16.0, )",
           "Fable.Core": "[4.3.0, )",
           "Fable.Node": "[1.2.0, )",
           "Fable.Promise": "[3.2.0, )",
@@ -55,6 +56,15 @@
         "dependencies": {
           "FSharp.Core": "4.7.2",
           "Fable.Core": "3.7.1"
+        }
+      },
+      "FsToolkit.ErrorHandling": {
+        "type": "CentralTransitive",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "GG4LtvJ/UkdyjGQUd+uPYN/g1GNlHyzMPDmwcnYvBn0V1dD4xJiiRE5N8UCgq+TSRQP11NNQUbzpU0zdxkrNbw==",
+        "dependencies": {
+          "FSharp.Core": "4.7.2"
         }
       },
       "Glutinum.Chalk": {

--- a/src/Glutinum.Converter/GlueAST.fs
+++ b/src/Glutinum.Converter/GlueAST.fs
@@ -266,6 +266,18 @@ type GlueUtilityType =
     | Record of GlueRecord
 // | ReadOnly of GlueType
 
+type GlueMappedType =
+    {
+        TypeParameter: GlueTypeParameter
+        Type: GlueType option
+    }
+
+type GlueIndexedAccessType =
+    {
+        IndexType: GlueType
+        ObjectType: GlueType
+    }
+
 [<RequireQualifiedAccess>]
 type GlueType =
     | Discard
@@ -278,7 +290,7 @@ type GlueType =
     | Union of GlueTypeUnion
     | Literal of GlueLiteral
     | KeyOf of GlueType
-    | IndexedAccessType of GlueType
+    | IndexedAccessType of GlueIndexedAccessType
     | ModuleDeclaration of GlueModuleDeclaration
     | ClassDeclaration of GlueClassDeclaration
     | TypeReference of GlueTypeReference
@@ -295,6 +307,7 @@ type GlueType =
     | ExportDefault of GlueType
     | TemplateLiteral
     | UtilityType of GlueUtilityType
+    | MappedType of GlueMappedType
 
     member this.Name =
         match this with
@@ -340,3 +353,4 @@ type GlueType =
             match utilityType with
             | GlueUtilityType.Partial _
             | GlueUtilityType.Record _ -> "obj"
+        | MappedType _ -> "obj"

--- a/src/Glutinum.Converter/Glutinum.Converter.fsproj
+++ b/src/Glutinum.Converter/Glutinum.Converter.fsproj
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>0.1.0-alpha-001</Version>
@@ -27,10 +26,12 @@
     <Compile Include="Reader/Node.fs" />
     <Compile Include="Reader/Parameters.fs" />
     <Compile Include="Reader/TypeAliasDeclaration.fs" />
+    <Compile Include="Reader/TypeQueryNode.fs" />
     <Compile Include="Reader/TypeNode.fs" />
     <Compile Include="Reader/TypeOperatorNode.fs" />
     <Compile Include="Reader/TypeParameters.fs" />
     <Compile Include="Reader/UnionTypeNode.fs" />
+    <Compile Include="Reader/MappedTypeNode.fs" />
     <Compile Include="Reader/VariableStatement.fs" />
     <Compile Include="Reader/ExportAssignment.fs" />
     <Compile Include="Reader/Documentation.fs" />
@@ -47,6 +48,7 @@
     <PackageReference Include="Fable.Core" />
     <PackageReference Include="Fable.Node" />
     <PackageReference Include="Fable.Promise" />
+    <PackageReference Include="FSToolkit.ErrorHandling" />
     <PackageReference Include="Glutinum.Chalk" />
   </ItemGroup>
 </Project>

--- a/src/Glutinum.Converter/Reader/IndexedAccessType.fs
+++ b/src/Glutinum.Converter/Reader/IndexedAccessType.fs
@@ -10,24 +10,52 @@ let readIndexedAccessType
     : GlueType
     =
 
-    let nodeType = declaration.indexType :?> Ts.TypeNode
+    let indexType =
+        let idxNodeType = declaration.indexType :?> Ts.TypeNode
 
-    let typ =
-        match nodeType.kind with
+        match idxNodeType.kind with
         | Ts.SyntaxKind.TypeOperator ->
             let typeOperatorNode = declaration.indexType :?> Ts.TypeOperatorNode
             reader.ReadTypeOperatorNode typeOperatorNode
+
+        | Ts.SyntaxKind.NumberKeyword ->
+            let numberKeywordNode = declaration.indexType :?> Ts.KeywordTypeNode
+            reader.ReadTypeNode(numberKeywordNode)
 
         | unsupported ->
             let warning =
                 Report.readerError (
                     "readIndexedAccessType",
-                    $"Unsupported node kind %s{unsupported.Name}",
-                    nodeType
+                    $"Unsupported node kind {unsupported.Name}",
+                    idxNodeType
                 )
 
             reader.Warnings.Add warning
 
             GlueType.Discard
 
-    GlueType.IndexedAccessType typ
+    let objectType =
+        let objNodeType = declaration.objectType :?> Ts.TypeNode
+
+        match objNodeType.kind with
+        | Ts.SyntaxKind.ParenthesizedType ->
+            let pType = declaration.objectType :?> Ts.ParenthesizedTypeNode
+            reader.ReadTypeNode pType
+
+        | unsupported ->
+            let warning =
+                Report.readerError (
+                    "readIndexedAccessType",
+                    $"Unsupported node kind %s{unsupported.Name}",
+                    objNodeType
+                )
+
+            reader.Warnings.Add warning
+
+            GlueType.Discard
+
+    GlueType.IndexedAccessType
+        {
+            IndexType = indexType
+            ObjectType = objectType
+        }

--- a/src/Glutinum.Converter/Reader/MappedTypeNode.fs
+++ b/src/Glutinum.Converter/Reader/MappedTypeNode.fs
@@ -1,0 +1,42 @@
+module Glutinum.Converter.Reader.MappedTypeNode
+
+open Glutinum.Converter.GlueAST
+open Glutinum.Converter.Reader.Types
+open TypeScript
+open FsToolkit.ErrorHandling
+
+let readMappedTypeNode
+    (reader: ITypeScriptReader)
+    (mappedTypeNode: Ts.MappedTypeNode)
+    : GlueType
+    =
+    result {
+        let! typParam =
+            // TODO: Make a single reader.ReadTypeParameter method
+            let typeParameters =
+                reader.ReadTypeParameters(
+                    Some(ResizeArray([ mappedTypeNode.typeParameter ]))
+                )
+
+            match typeParameters with
+            | [ tp ] -> Ok tp
+            | _ ->
+                Report.readerError (
+                    "readMappedTypeNode",
+                    $"Expected exactly one type parameter but was {List.length typeParameters}",
+                    mappedTypeNode
+                )
+                |> Error
+
+        return
+            {
+                TypeParameter = typParam
+                Type = mappedTypeNode.``type`` |> Option.map reader.ReadNode
+            }
+            |> GlueType.MappedType
+    }
+    |> function
+        | Ok glueType -> glueType
+        | Error warning ->
+            reader.Warnings.Add warning
+            GlueType.Discard

--- a/src/Glutinum.Converter/Reader/Node.fs
+++ b/src/Glutinum.Converter/Reader/Node.fs
@@ -47,6 +47,8 @@ let readNode (reader: ITypeScriptReader) (node: Ts.Node) : GlueType =
 
     | Ts.SyntaxKind.ExportDeclaration -> GlueType.Discard
 
+    | Ts.SyntaxKind.BooleanKeyword -> reader.ReadTypeNode(node :?> Ts.TypeNode)
+
     | unsupported ->
         let warning =
             Report.readerError (

--- a/src/Glutinum.Converter/Reader/TypeAliasDeclaration.fs
+++ b/src/Glutinum.Converter/Reader/TypeAliasDeclaration.fs
@@ -25,6 +25,10 @@ let readTypeAliasDeclaration
             let declaration = declaration.``type`` :?> Ts.IndexedAccessType
             reader.ReadIndexedAccessType declaration
 
+        | Ts.SyntaxKind.MappedType ->
+            let mappedTypeNode = declaration.``type`` :?> Ts.MappedTypeNode
+            reader.ReadMappedTypeNode mappedTypeNode
+
         | _ -> reader.ReadTypeNode declaration.``type``
 
     {

--- a/src/Glutinum.Converter/Reader/TypeNode.fs
+++ b/src/Glutinum.Converter/Reader/TypeNode.fs
@@ -219,11 +219,8 @@ let readTypeNode
         |> GlueType.FunctionType
 
     | Ts.SyntaxKind.TypeQuery ->
-        let typeNodeQuery = typeNode :?> Ts.TypeQueryNode
-
-        let typ = checker.getTypeAtLocation !!typeNodeQuery.exprName
-
-        readTypeUsingFlags reader typ
+        let typeQueryNode = typeNode :?> Ts.TypeQueryNode
+        TypeQueryNode.readTypeQueryNode reader typeQueryNode
 
     | Ts.SyntaxKind.LiteralType ->
         let literalTypeNode = typeNode :?> Ts.LiteralTypeNode
@@ -391,6 +388,10 @@ let readTypeNode
         | forward -> forward
 
     | Ts.SyntaxKind.TemplateLiteralType -> GlueType.TemplateLiteral
+
+    | Ts.SyntaxKind.IndexedAccessType ->
+        let indexedAccessType = typeNode :?> Ts.IndexedAccessType
+        reader.ReadIndexedAccessType indexedAccessType
 
     | _ ->
         Report.readerError (

--- a/src/Glutinum.Converter/Reader/TypeQueryNode.fs
+++ b/src/Glutinum.Converter/Reader/TypeQueryNode.fs
@@ -1,0 +1,153 @@
+module Glutinum.Converter.Reader.TypeQueryNode
+
+open Glutinum.Converter.GlueAST
+open Glutinum.Converter.Reader.Types
+open TypeScript
+open Fable.Core.JsInterop
+open Glutinum.Converter.Reader.Utils
+open FsToolkit.ErrorHandling
+
+let readTypeQueryNode
+    (reader: ITypeScriptReader)
+    (typeQueryNode: Ts.TypeQueryNode)
+    =
+
+    let checker = reader.checker
+    let typ = checker.getTypeAtLocation !!typeQueryNode.exprName
+
+    match typ.flags with
+    | HasTypeFlags Ts.TypeFlags.Object ->
+        // This is safe as both cases have a `kind` field
+        let exprNameKind: Ts.SyntaxKind = typeQueryNode.exprName?kind
+
+        match typ.getSymbol (), exprNameKind with
+        | None, Ts.SyntaxKind.Identifier ->
+
+            let exprName: Ts.Identifier = !!typeQueryNode.exprName
+
+            result {
+                let! aliasSymbol =
+                    checker.getSymbolAtLocation exprName
+                    |> Result.requireSome (
+                        Report.readerError (
+                            "type node (TypeQuery)",
+                            "Missing symbol",
+                            typeQueryNode
+                        )
+                    )
+
+                let! declarations =
+                    aliasSymbol.declarations
+                    |> Result.requireSome (
+                        Report.readerError (
+                            "type node (TypeQuery)",
+                            "Missing declarations",
+                            typeQueryNode
+                        )
+                    )
+
+                let! declaration =
+                    if declarations.Count <> 1 then
+                        Report.readerError (
+
+                            "type node (TypeQuery)",
+                            "Expected exactly one declaration",
+                            typeQueryNode
+                        )
+                        |> Error
+
+                    else
+                        Ok(declarations.[0])
+
+                let! variableDeclaration =
+                    match declaration.kind with
+                    | Ts.SyntaxKind.VariableDeclaration ->
+                        Ok(declaration :?> Ts.VariableDeclaration)
+
+                    | unsupported ->
+                        Report.readerError (
+                            "type node (TypeQuery)",
+                            $"Unsupported declaration kind {unsupported.Name}",
+                            typeQueryNode
+                        )
+                        |> Error
+
+                let! typeNode =
+                    variableDeclaration.``type``
+                    |> Result.requireSome (
+                        Report.readerError (
+                            "type node (TypeQuery)",
+                            "Missing type",
+                            typeQueryNode
+                        )
+                    )
+
+                match typeNode.kind with
+                | Ts.SyntaxKind.TypeOperator ->
+                    let typeOperatorNode = typeNode :?> Ts.TypeOperatorNode
+                    return reader.ReadTypeOperatorNode typeOperatorNode
+
+                | unsupported ->
+                    return!
+                        Report.readerError (
+                            "type node (TypeQuery)",
+                            $"Unsupported declaration kind {unsupported.Name}",
+                            typeQueryNode
+                        )
+                        |> Error
+
+            }
+            |> function
+                | Ok glueType -> glueType
+                | Error warning ->
+                    reader.Warnings.Add warning
+                    GlueType.Discard
+
+        | None, _ ->
+            let warning =
+                Report.readerError (
+                    "type node (TypeQuery)",
+                    "Expected an Identifier",
+                    typeQueryNode
+                )
+
+            reader.Warnings.Add warning
+            GlueType.Primitive GluePrimitive.Any
+
+        | Some symbol, _ ->
+            // Try to find the declaration of the type, to get more information about it
+            match symbol.declarations with
+            | Some declarations ->
+                let declaration = declarations.[0]
+
+                match declaration.kind with
+                | Ts.SyntaxKind.ClassDeclaration ->
+                    {
+                        Name = symbol.name
+                        Constructors = []
+                        Members = []
+                        TypeParameters = []
+                        HeritageClauses = []
+                    }
+                    |> GlueType.ClassDeclaration
+
+                // We don't support TypeQuery for ModuleDeclaration yet
+                // See https://github.com/glutinum-org/cli/issues/70 for a possible solution
+                | Ts.SyntaxKind.ModuleDeclaration -> GlueType.Discard
+                | _ -> reader.ReadNode declaration
+
+            | None -> GlueType.Primitive GluePrimitive.Any
+
+    | HasTypeFlags Ts.TypeFlags.String ->
+        GlueType.Primitive GluePrimitive.String
+
+    | HasTypeFlags Ts.TypeFlags.Number ->
+        GlueType.Primitive GluePrimitive.Number
+
+    | HasTypeFlags Ts.TypeFlags.Boolean -> GlueType.Primitive GluePrimitive.Bool
+
+    | HasTypeFlags Ts.TypeFlags.Any -> GlueType.Primitive GluePrimitive.Any
+
+    | HasTypeFlags Ts.TypeFlags.Void -> GlueType.Primitive GluePrimitive.Unit
+
+    | _ -> GlueType.Primitive GluePrimitive.Any

--- a/src/Glutinum.Converter/Reader/TypeScriptReader.fs
+++ b/src/Glutinum.Converter/Reader/TypeScriptReader.fs
@@ -8,6 +8,7 @@ open Glutinum.Converter.Reader.EnumDeclaration
 open Glutinum.Converter.Reader.FunctionDeclaration
 open Glutinum.Converter.Reader.IndexedAccessType
 open Glutinum.Converter.Reader.InterfaceDeclaration
+open Glutinum.Converter.Reader.MappedTypeNode
 open Glutinum.Converter.Reader.ModuleDeclaration
 open Glutinum.Converter.Reader.Declaration
 open Glutinum.Converter.Reader.Node
@@ -146,3 +147,9 @@ type TypeScriptReader(checker: Ts.TypeChecker) =
             : GlueType
             =
             readNamedTupleMember this namedTupleMember
+
+        member this.ReadMappedTypeNode
+            (declaration: Ts.MappedTypeNode)
+            : GlueType
+            =
+            readMappedTypeNode this declaration

--- a/src/Glutinum.Converter/Reader/Types.fs
+++ b/src/Glutinum.Converter/Reader/Types.fs
@@ -66,3 +66,5 @@ type ITypeScriptReader =
 
     abstract ReadNamedTupleMember:
         namedTupleMember: Ts.NamedTupleMember -> GlueType
+
+    abstract ReadMappedTypeNode: declaration: Ts.MappedTypeNode -> GlueType

--- a/src/Glutinum.Converter/packages.lock.json
+++ b/src/Glutinum.Converter/packages.lock.json
@@ -34,6 +34,15 @@
         "resolved": "8.0.101",
         "contentHash": "sOLz3O4BOxnTKfd5OChdRmDUy4Id0GfoEClRG4nzIod8LY1LJZcNyygKAV0A78XOLh8yvhA5hsDYKZXGCR9blw=="
       },
+      "FsToolkit.ErrorHandling": {
+        "type": "Direct",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "GG4LtvJ/UkdyjGQUd+uPYN/g1GNlHyzMPDmwcnYvBn0V1dD4xJiiRE5N8UCgq+TSRQP11NNQUbzpU0zdxkrNbw==",
+        "dependencies": {
+          "FSharp.Core": "4.7.2"
+        }
+      },
       "Glutinum.Chalk": {
         "type": "Direct",
         "requested": "[1.0.0, )",

--- a/src/Glutinum.Web/Pages/Editors.GlueAST.GlueASTViewer.fs
+++ b/src/Glutinum.Web/Pages/Editors.GlueAST.GlueASTViewer.fs
@@ -406,7 +406,10 @@ type GlueASTViewer =
         | GlueType.IndexedAccessType indexedAccessType ->
             ASTViewer.renderNode
                 "IndexedAccessType"
-                [ GlueASTViewer.Type indexedAccessType ]
+                [
+                    GlueASTViewer.Type indexedAccessType.IndexType
+                    GlueASTViewer.Type indexedAccessType.ObjectType
+                ]
                 context
 
         | GlueType.KeyOf keyOf ->
@@ -426,6 +429,18 @@ type GlueASTViewer =
                     moduleDeclaration.Types
                     |> List.map GlueASTViewer.GlueType
                     |> ASTViewer.renderNode "Types"
+                ]
+                context
+
+        | GlueType.MappedType mappedType ->
+            ASTViewer.renderNode
+                "MappedType"
+                [
+                    match mappedType.Type with
+                    | Some ty -> GlueASTViewer.Type ty
+                    | None -> ()
+
+                    GlueASTViewer.TypeParameters [ mappedType.TypeParameter ]
                 ]
                 context
 

--- a/src/Glutinum.Web/packages.lock.json
+++ b/src/Glutinum.Web/packages.lock.json
@@ -322,6 +322,7 @@
       "glutinum.converter": {
         "type": "Project",
         "dependencies": {
+          "FSToolkit.ErrorHandling": "[4.16.0, )",
           "Fable.Core": "[4.3.0, )",
           "Fable.Node": "[1.2.0, )",
           "Fable.Promise": "[3.2.0, )",
@@ -346,6 +347,15 @@
         "dependencies": {
           "FSharp.Core": "4.7.2",
           "Fable.Core": "3.7.1"
+        }
+      },
+      "FsToolkit.ErrorHandling": {
+        "type": "CentralTransitive",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "GG4LtvJ/UkdyjGQUd+uPYN/g1GNlHyzMPDmwcnYvBn0V1dD4xJiiRE5N8UCgq+TSRQP11NNQUbzpU0zdxkrNbw==",
+        "dependencies": {
+          "FSharp.Core": "4.7.2"
         }
       },
       "Glutinum.Chalk": {

--- a/tests/specs/references/typeof/typeofStrings.d.ts
+++ b/tests/specs/references/typeof/typeofStrings.d.ts
@@ -1,0 +1,4 @@
+declare const NODES: readonly ["a", "button"];
+type Primitives = {
+    [E in (typeof NODES)[number]]: boolean;
+};

--- a/tests/specs/references/typeof/typeofStrings.fsx
+++ b/tests/specs/references/typeof/typeofStrings.fsx
@@ -1,0 +1,16 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+
+[<AllowNullLiteral>]
+[<Interface>]
+type Primitives =
+    abstract member a: bool with get, set
+    abstract member button: bool with get, set
+
+(***)
+#r "nuget: Fable.Core"
+(***)


### PR DESCRIPTION
```ts
declare const NODES: readonly ["a", "button"];
type Primitives = {
    [E in (typeof NODES)[number]]: boolean;
};
```

transforms to

```fs
[<AllowNullLiteral>]
[<Interface>]
type Primitives =
    abstract member a: bool with get, set
    abstract member button: bool with get, set
```

## Summary

- Adds new `GlueType.MappedType` #119 
- Adds `ObjectType` to `IndexedAccessType`
- Adds corresponding transform functions
- Introduces `FsToolkit.ErrorHandling` to improve readability #123 