### PR TITLE
fix: type constraint should not be generated when the type is a "return type"

### DIFF
--- a/src/Glutinum.Converter/Printer.fs
+++ b/src/Glutinum.Converter/Printer.fs
@@ -163,8 +163,50 @@ let private printAttributes
         printer.NewLine
     )
 
-let rec private tryTransformTypeParametersToText
-    (isDeclaration: bool)
+let rec printTypeParametersDeclaration
+    (printer: Printer)
+    (typeParameters: FSharpTypeParameter list)
+    =
+    let innterPrinter = new Printer()
+
+    if not typeParameters.IsEmpty then
+        innterPrinter.WriteInline("<")
+
+        typeParameters
+        |> List.iteri (fun index typeParameter ->
+            if index <> 0 then
+                innterPrinter.WriteInline(", ")
+
+            innterPrinter.WriteInline($"'{typeParameter.Name}")
+        )
+
+        // Print the constraints only if we are in the initial declaration.
+        // We want to avoid situations like the following:
+        // static member User<'T when 'T :> A> () : User<'T when 'T :> A> = nativeOnly
+        // Which should be:
+        // static member User<'T when 'T :> A> () : User<'T> = nativeOnly
+        typeParameters
+        |> List.filter _.Constraint.IsSome
+        |> List.iteri (fun index typeParameter ->
+            match typeParameter.Constraint with
+            | Some constraint_ ->
+                if index = 0 then
+                    innterPrinter.WriteInline(" when ")
+                else
+                    innterPrinter.WriteInline(" and ")
+
+                innterPrinter.WriteInline($"'{typeParameter.Name}")
+                innterPrinter.WriteInline(" :> ")
+                innterPrinter.WriteInline(printType constraint_)
+            | None -> ()
+        )
+
+        innterPrinter.WriteInline(">")
+
+        innterPrinter.ToStringWithoutTrailNewLine() |> printer.WriteInline
+
+and printTypeNameWithTypeParameters
+    (name: string)
     (typeParameters: FSharpTypeParameter list)
     =
     let printer = new Printer()
@@ -180,66 +222,15 @@ let rec private tryTransformTypeParametersToText
             printer.WriteInline($"'{typeParameter.Name}")
         )
 
-        // Print the constraints only if we are in the initial declaration.
-        // We want to avoid situations like the following:
-        // static member User<'T when 'T :> A> () : User<'T when 'T :> A> = nativeOnly
-        // Which should be:
-        // static member User<'T when 'T :> A> () : User<'T> = nativeOnly
-        if isDeclaration then
-            typeParameters
-            |> List.filter _.Constraint.IsSome
-            |> List.iteri (fun index typeParameter ->
-                match typeParameter.Constraint with
-                | Some constraint_ ->
-                    if index = 0 then
-                        printer.WriteInline(" when ")
-                    else
-                        printer.WriteInline(" and ")
-
-                    printer.WriteInline($"'{typeParameter.Name}")
-                    printer.WriteInline(" :> ")
-                    printer.WriteInline(printType constraint_)
-                | None -> ()
-            )
-
         printer.WriteInline(">")
 
-        printer.ToStringWithoutTrailNewLine() |> Some
-
-    else
-        None
-
-and printTypeParameters
-    (printer: Printer)
-    (typeParameters: FSharpTypeParameter list)
-    =
-    let isDeclaration = true
-
-    match tryTransformTypeParametersToText isDeclaration typeParameters with
-    | Some typeParameters -> printer.WriteInline(typeParameters)
-    | None -> ()
+    $"{name}{printer.ToStringWithoutTrailNewLine()}"
 
 and printType (fsharpType: FSharpType) =
-    let printTypeNameWithTypeParameters
-        (name: string)
-        (typeParameters: FSharpTypeParameter list)
-        =
-        let isDeclaration = false
-
-        match tryTransformTypeParametersToText isDeclaration typeParameters with
-        | Some typeParameters -> $"{name}{typeParameters}"
-        | None -> name
-
     match fsharpType with
     | FSharpType.Object -> "obj"
     | FSharpType.Mapped info ->
-        let isDeclaration = false
-
-        match
-            tryTransformTypeParametersToText isDeclaration info.TypeParameters
-        with
-        | Some typeParameters -> $"{info.Name}{typeParameters}"
-        | None -> info.Name
+        printTypeNameWithTypeParameters info.Name info.TypeParameters
 
     | FSharpType.SingleErasedCaseUnion info -> info.Name
 
@@ -518,7 +509,7 @@ let private printInterface (printer: Printer) (interfaceInfo: FSharpInterface) =
     printAttributes printer interfaceInfo.Attributes
 
     printer.Write($"type {interfaceInfo.Name}")
-    printTypeParameters printer interfaceInfo.TypeParameters
+    printTypeParametersDeclaration printer interfaceInfo.TypeParameters
     printer.WriteInline(" =")
     printer.NewLine
 
@@ -547,7 +538,7 @@ let private printInterface (printer: Printer) (interfaceInfo: FSharpInterface) =
 
             printer.WriteInline($"member {methodInfo.Name}")
 
-            printTypeParameters printer methodInfo.TypeParameters
+            printTypeParametersDeclaration printer methodInfo.TypeParameters
 
             if methodInfo.IsStatic then
                 printer.WriteInline(" ")
@@ -719,7 +710,9 @@ import {{ %s{interfaceInfo.OriginalName} }} from \"{Naming.MODULE_PLACEHOLDER}\"
 
             printer.Write($"static member inline {staticMemberInfo.Name} ")
 
-            printTypeParameters printer staticMemberInfo.TypeParameters
+            printTypeParametersDeclaration
+                printer
+                staticMemberInfo.TypeParameters
 
             if staticMemberInfo.Parameters.IsEmpty then
                 printer.WriteInline("() : ")
@@ -826,7 +819,7 @@ let private printClass (printer: Printer) (classInfo: FSharpClass) =
     printAttributes printer classInfo.Attributes
 
     printer.Write($"type {classInfo.Name}")
-    printTypeParameters printer classInfo.TypeParameters
+    printTypeParametersDeclaration printer classInfo.TypeParameters
     printer.NewLine
     printer.Indent
     printPrimaryConstructor printer classInfo.PrimaryConstructor
@@ -912,7 +905,7 @@ let private printTypeAlias (printer: Printer) (aliasInfo: FSharpTypeAlias) =
     printAttributes printer aliasInfo.Attributes
 
     printer.Write($"type {aliasInfo.Name}")
-    printTypeParameters printer aliasInfo.TypeParameters
+    printTypeParametersDeclaration printer aliasInfo.TypeParameters
     printer.WriteInline(" =")
 
     printer.NewLine
@@ -923,7 +916,7 @@ let private printTypeAlias (printer: Printer) (aliasInfo: FSharpTypeAlias) =
 
 let private printDelegate (printer: Printer) (delegateInfo: FSharpDelegate) =
     printer.Write($"type {delegateInfo.Name}")
-    printTypeParameters printer delegateInfo.TypeParameters
+    printTypeParametersDeclaration printer delegateInfo.TypeParameters
     printer.WriteInline(" =")
 
     printer.NewLine
@@ -1007,7 +1000,11 @@ let rec private print (printer: Printer) (fsharpTypes: FSharpType list) =
                 (FSharpAttribute.Erase :: erasedCaseUnionInfo.Attributes)
 
             printer.Write($"type {erasedCaseUnionInfo.Name}")
-            printTypeParameters printer [ erasedCaseUnionInfo.TypeParameter ]
+
+            printTypeParametersDeclaration
+                printer
+                [ erasedCaseUnionInfo.TypeParameter ]
+
             printer.WriteInline(" =")
 
             printer.NewLine

--- a/src/Glutinum.Converter/Printer.fs
+++ b/src/Glutinum.Converter/Printer.fs
@@ -180,6 +180,11 @@ let rec private tryTransformTypeParametersToText
             printer.WriteInline($"'{typeParameter.Name}")
         )
 
+        // Print the constraints only if we are in the initial declaration.
+        // We want to avoid situations like the following:
+        // static member User<'T when 'T :> A> () : User<'T when 'T :> A> = nativeOnly
+        // Which should be:
+        // static member User<'T when 'T :> A> () : User<'T> = nativeOnly
         if isDeclaration then
             typeParameters
             |> List.filter _.Constraint.IsSome

--- a/tests/specs/references/class/generics/oneWithConstraint.d.ts
+++ b/tests/specs/references/class/generics/oneWithConstraint.d.ts
@@ -1,0 +1,3 @@
+class A {}
+
+class User<T extends A = A> {}

--- a/tests/specs/references/class/generics/oneWithConstraint.fsx
+++ b/tests/specs/references/class/generics/oneWithConstraint.fsx
@@ -1,0 +1,28 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+[<AbstractClass>]
+[<Erase>]
+type Exports =
+    [<Import("A", "REPLACE_ME_WITH_MODULE_NAME"); EmitConstructor>]
+    static member A () : A = nativeOnly
+    [<Import("User", "REPLACE_ME_WITH_MODULE_NAME"); EmitConstructor>]
+    static member User<'T when 'T :> A> () : User<'T> = nativeOnly
+
+[<AllowNullLiteral>]
+[<Interface>]
+type A =
+    interface end
+
+[<AllowNullLiteral>]
+[<Interface>]
+type User<'T when 'T :> A> =
+    interface end
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)


### PR DESCRIPTION
Fixes https://github.com/glutinum-org/cli/issues/153

The issue is that sometimes the type constraints are being printed when they shouldn't be.  They should only be printed on the initial type declaration.  This adds a flag to check if it's a declaration.  If not, the type constraint is omitted.

Tests all pass, but it could definitely use a closer look of someone more familiar with the project.