### PR TITLE
feat: Add support for additional Fable.Core.JS types

### DIFF
--- a/src/Glutinum.Converter/Transform.fs
+++ b/src/Glutinum.Converter/Transform.fs
@@ -145,7 +145,6 @@ let private mapTypeNameToFableCoreAwareName
     (context: TransformContext)
     (typeReference: GlueTypeReference)
     =
-
     let mappedName =
         // When exposing a type, we also need to do it
         if typeReference.IsStandardLibrary then
@@ -153,6 +152,14 @@ let private mapTypeNameToFableCoreAwareName
             | "Date" -> "JS.Date"
             | "Promise" -> "JS.Promise"
             | "Uint8Array" -> "JS.Uint8Array"
+            | "Int8Array" -> "JS.Int8Array"
+            | "Uint8ClampedArray" -> "JS.Uint8ClampedArray"
+            | "Int16Array" -> "JS.Int16Array"
+            | "Uint16Array" -> "JS.Uint16Array"
+            | "Int32Array" -> "JS.Int32Array"
+            | "Uint32Array" -> "JS.Uint32Array"
+            | "Float32Array" -> "JS.Float32Array"
+            | "Float64Array" -> "JS.Float64Array"
             | "Array" -> "ResizeArray"
             | "Boolean" -> "bool"
             | "Function" -> "Action"

--- a/tests/specs/references/replacements/Float32Array.d.ts
+++ b/tests/specs/references/replacements/Float32Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Float32Array;

--- a/tests/specs/references/replacements/Float32Array.fsx
+++ b/tests/specs/references/replacements/Float32Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Float32Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Float64Array.d.ts
+++ b/tests/specs/references/replacements/Float64Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Float64Array;

--- a/tests/specs/references/replacements/Float64Array.fsx
+++ b/tests/specs/references/replacements/Float64Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Float64Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Int16Array.d.ts
+++ b/tests/specs/references/replacements/Int16Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Int16Array;

--- a/tests/specs/references/replacements/Int16Array.fsx
+++ b/tests/specs/references/replacements/Int16Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Int16Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Int32Array.d.ts
+++ b/tests/specs/references/replacements/Int32Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Int32Array;

--- a/tests/specs/references/replacements/Int32Array.fsx
+++ b/tests/specs/references/replacements/Int32Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Int32Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Int8Array.d.ts
+++ b/tests/specs/references/replacements/Int8Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Int8Array;

--- a/tests/specs/references/replacements/Int8Array.fsx
+++ b/tests/specs/references/replacements/Int8Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Int8Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Uint16Array.d.ts
+++ b/tests/specs/references/replacements/Uint16Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Uint16Array;

--- a/tests/specs/references/replacements/Uint16Array.fsx
+++ b/tests/specs/references/replacements/Uint16Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Uint16Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Uint32Array.d.ts
+++ b/tests/specs/references/replacements/Uint32Array.d.ts
@@ -1,0 +1,1 @@
+export type T = Uint32Array;

--- a/tests/specs/references/replacements/Uint32Array.fsx
+++ b/tests/specs/references/replacements/Uint32Array.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Uint32Array
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)

--- a/tests/specs/references/replacements/Uint8ClampedArray.d.ts
+++ b/tests/specs/references/replacements/Uint8ClampedArray.d.ts
@@ -1,0 +1,1 @@
+export type T = Uint8ClampedArray;

--- a/tests/specs/references/replacements/Uint8ClampedArray.fsx
+++ b/tests/specs/references/replacements/Uint8ClampedArray.fsx
@@ -1,0 +1,13 @@
+module rec Glutinum
+
+open Fable.Core
+open Fable.Core.JsInterop
+open System
+
+type T =
+    JS.Uint8ClampedArray
+
+(***)
+#r "nuget: Fable.Core"
+#r "nuget: Glutinum.Types"
+(***)


### PR DESCRIPTION
Fixes https://github.com/glutinum-org/cli/issues/170 .  Adds a few more types from `Fable.Core.JS`.

I tried to add `BigInt64Array` but was getting some error.  I think it has something to do with this code:

```fsharp
/// <summary>
/// Determine if the type is from the ES5 library
///
/// This is to detect native utility types usage
/// </summary>
/// <param name="symbolOpt"></param>
/// <returns>
/// <c>True</c> if the type is from the ES5 library otherwise <c>False</c>
/// </returns>
let isFromEs5Lib (symbolOpt: Ts.Symbol option) =
    match symbolOpt with
    | None -> false
    | Some symbol ->
        match symbol.declarations with
        | None ->
            // For some reason, I can't seem to resolve the actual symbol for some Es5 types
            // So, we make a naive fallback checking the name of the symbol
            [ "Iterable"; "IterableIterator" ] |> List.contains symbol.name
        | Some declarations ->
            match declarations[0].parent.kind with
            | Ts.SyntaxKind.SourceFile ->
                let sourceFile = declarations[0].parent :?> Ts.SourceFile

                sourceFile.fileName.EndsWith("lib/lib.es5.d.ts")
```

`BigInt64Array` is from [ECMAScript 2020](https://stackoverflow.com/questions/6041124/javascript-typed-arrays-64-bit-integers).  I haven't actually figured out how to debug this project and it's not in the file I'm interested in converting (the VS Code `index.d.ts`) so for now I just decided to leave it out.